### PR TITLE
Fix Cell.cs

### DIFF
--- a/TonLibDotNet/Cells/Cell.cs
+++ b/TonLibDotNet/Cells/Cell.cs
@@ -9,10 +9,10 @@ namespace TonLibDotNet.Cells
         public const int MaxBitsCount = 1023;
         public const int MaxRefs = 4;
 
-        public Cell(ReadOnlySpan<byte> content, bool isAugmented, ICollection<Cell>? refs = null)
-            : this(false, refs?.Max(x => x.Level) ?? 0, content, isAugmented, refs)
+       public Cell(ReadOnlySpan<byte> content, bool isAugmented, ICollection<Cell>? refs = null)
+        	: this(false, refs != null && refs.Any() ? refs.Max(x => x.Level) : (byte)0, content, isAugmented, refs)
         {
-            // Nothing.
+        	// Nothing.
         }
 
         public Cell(bool isExotic, byte level, ReadOnlySpan<byte> content, bool isAugmented, ICollection<Cell>? refs = null)

--- a/TonLibDotNet/Cells/Cell.cs
+++ b/TonLibDotNet/Cells/Cell.cs
@@ -9,13 +9,14 @@ namespace TonLibDotNet.Cells
         public const int MaxBitsCount = 1023;
         public const int MaxRefs = 4;
 
-       public Cell(ReadOnlySpan<byte> content, bool isAugmented, ICollection<Cell>? refs = null)
-        	: this(false, refs != null && refs.Any() ? refs.Max(x => x.Level) : (byte)0, content, isAugmented, refs)
-        {
-        	// Nothing.
-        }
+		public Cell(ReadOnlySpan<byte> content, bool isAugmented, ICollection<Cell>? refs = null)
+	        : this(false, refs != null && refs.Count > 0 ? refs.Max(x => x.Level) : (byte)0, content, isAugmented, refs)
+		{
+			// Nothing.
+		}
 
-        public Cell(bool isExotic, byte level, ReadOnlySpan<byte> content, bool isAugmented, ICollection<Cell>? refs = null)
+
+		public Cell(bool isExotic, byte level, ReadOnlySpan<byte> content, bool isAugmented, ICollection<Cell>? refs = null)
         {
             if (content.Length > MaxContentLength)
             {


### PR DESCRIPTION
Fix: Added empty refs collection check in Cell constructor

Before computing the maximum level from the refs collection, a check is now performed to ensure that the collection is not empty. If the collection is empty, the level is set to 0 (explicitly cast to byte), preventing the "Sequence contains no elements" exception during cell construction.